### PR TITLE
Rename references to debops_rails

### DIFF
--- a/docs/ansible/roles/debops.rails_deploy.rst
+++ b/docs/ansible/roles/debops.rails_deploy.rst
@@ -436,7 +436,7 @@ hosts
 
 ::
 
-    [debops_rails]
+    [debops_rails_deploy]
     somehost
 
 inventory/host_vars/somehost.yml
@@ -461,7 +461,7 @@ playbook
     # playbooks/custom.yml
 
     - name: Deploy yourappname
-      hosts: debops_rails
+      hosts: debops_rails_deploy
       sudo: true
 
       roles:


### PR DESCRIPTION
The README is inconsistent, which can cause errors when deploying using the default settings.
Closes https://github.com/debops/ansible-rails_deploy/issues/18

— @Faun & @DTrejo