### PR TITLE
Default highlight_language is YAML.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -97,6 +97,11 @@ exclude_patterns = ['_build','debops/*.rst','debops-playbooks/*.rst','ansible/ro
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'
 
+# The default language to highlight source code in. The default is 'python'.
+# The value should be a valid Pygments lexer name, see Showing code examples
+# for more details.
+highlight_language = 'YAML'
+
 # A list of ignored prefixes for module index sorting.
 #modindex_common_prefix = []
 


### PR DESCRIPTION
http://sphinx-doc.org/config.html?highlight=highlight#confval-highlight_language

When a language is not YAML we will have to make that explicit.

This patch allows to use:

```
Example::

yaml_var: [ 23 ]
```

Which will then be highlighted as YAML.