### PR TITLE
Updated to Sphinx 1.3 to allow using :any: to reference vars.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -243,15 +243,20 @@
 [submodule "docs/ansible/roles/ansible-gitlab_runner"]
 	path = docs/ansible/roles/ansible-gitlab_runner
 	url = https://github.com/debops/ansible-gitlab_runner
+	ignore = untracked
 [submodule "docs/ansible/roles/ansible-logrotate"]
 	path = docs/ansible/roles/ansible-logrotate
 	url = https://github.com/debops/ansible-logrotate
+	ignore = untracked
 [submodule "docs/ansible/roles/ansible-ferm"]
 	path = docs/ansible/roles/ansible-ferm
 	url = https://github.com/debops/ansible-ferm
+	ignore = untracked
 [submodule "docs/ansible/roles/ansible-rsyslog"]
 	path = docs/ansible/roles/ansible-rsyslog
 	url = https://github.com/debops/ansible-rsyslog
+	ignore = untracked
 [submodule "docs/ansible/roles/ansible-ntp"]
 	path = docs/ansible/roles/ansible-ntp
 	url = https://github.com/debops/ansible-ntp
+	ignore = untracked

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
   - "2.7"
 
 # command to install dependencies
-install: "pip install -q yaml2rst sphinx==1.2.2"
+install: "pip install -q yaml2rst sphinx==1.3.4"
 
 # command to run tests
 script: ./test.sh -W


### PR DESCRIPTION
Refer to the [Sphinx documentation about `:any:`](http://www.sphinx-doc.org/en/stable/markup/inline.html#role-any).
`:any:` can be used in Sphinx to reference variables. Example:

```YAML
# .. envvar:: ferm__enabled
#
# Some text.
ferm__enabled: True


# .. envvar:: ferm__flush
#
# Some text.
# You might also need to change :any:`ferm__enabled`.
# Some text.
ferm__flush: '{{ ferm__enabled | bool }}'
```

When using this, we might need to adjust sections names. Example:


```reStructuredText
.. _ferm_input_list:

ferm_input_list
---------------
```

could be changed to:


```reStructuredText
.. _ferm_detailed_input_list:

ferm_input_list
---------------
```

to avoid duplicates. The good thing is that Sphinx as of 1.3.4 warns when referencing a label for which multiple targets exist.

1.3.4 has been chosen because it is the current version in [jessie-backports](https://packages.debian.org/jessie-backports/python-sphinx).
