### PR TITLE
Don‘t warn about include files not being included in any toctree.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -263,6 +263,8 @@
 [submodule "docs/ansible/roles/ansible-apt_install"]
 	path = docs/ansible/roles/ansible-apt_install
 	url = https://github.com/debops/ansible-apt_install
+	ignore = untracked
 [submodule "docs/ansible/roles/ansible-tcpwrappers"]
 	path = docs/ansible/roles/ansible-tcpwrappers
 	url = https://github.com/debops/ansible-tcpwrappers
+	ignore = untracked

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -77,7 +77,8 @@ release = 'master'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ['_build','debops/*.rst','debops-playbooks/*.rst','ansible/roles/ansible-*/*.rst','ansible/roles/ansible-*/docs/parts']
+# 'includes/*.rst': https://github.com/debops/docs/issues/144
+exclude_patterns = ['_build', 'debops/*.rst', 'debops-playbooks/*.rst', 'ansible/roles/ansible-*/*.rst', 'ansible/roles/ansible-*/docs/parts', 'includes/*.rst']
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.

--- a/update-submodules
+++ b/update-submodules
@@ -32,7 +32,7 @@ else
     # Get latest updates from all submodules
     git submodule update --init --remote
 
-    # Check if there are uncommited changes
+    # Check if there are uncommitted changes
     if ! $(git diff --quiet && git diff --cached --quiet) ; then
 
 	# Commit all changes


### PR DESCRIPTION
`includes/*.rst` files can be used to define global and role specific hyperlink targets.

Examples:

* https://github.com/ypid/ypid-ansible-common/tree/master/template_role/docs
* https://github.com/ypid/ansible-x2go_server/tree/master/docs