### PR TITLE
`exclude_patterns` must match the whole path.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -78,7 +78,7 @@ release = 'master'
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # 'includes/*.rst': https://github.com/debops/docs/issues/144
-exclude_patterns = ['_build', 'debops/*.rst', 'debops-playbooks/*.rst', 'ansible/roles/ansible-*/*.rst', 'ansible/roles/ansible-*/docs/parts', 'includes/*.rst']
+exclude_patterns = ['_build', 'debops/*.rst', 'debops-playbooks/*.rst', 'ansible/roles/ansible-*/*.rst', 'ansible/roles/ansible-*/docs/parts', '**includes/*.rst']
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.


### PR DESCRIPTION
Fixes: https://github.com/debops/docs/pull/144