### PR TITLE
Fully support the DebOps fold format for yaml+rst files.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,6 +24,7 @@ for element in os.listdir('ansible/roles'):
       'ansible/roles/' + element + '/defaults/main.yml',
       'ansible/roles/' + element + '/docs/defaults.rst',
       strip_regex=r'\s*(:?\[{3}|\]{3})\d?$',
+      yaml_strip_regex=r'^\s{66,67}#\s\]{3}\d?$',
     )
 
 # If extensions (or modules to document with autodoc) are in another directory,

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,4 +2,4 @@ sphinx==1.3.4
 
 ## TODO: Install unreleased develop version until htgoebel makes a release.
 # yaml2rst
-https://github.com/ypid/yaml2rst/archive/feature/expose-strip_regex.zip
+https://github.com/ypid/yaml2rst/archive/feature/yaml-fold-strip.zip


### PR DESCRIPTION
Uses: https://github.com/htgoebel/yaml2rst/pull/6
Related to: https://github.com/debops/docs/issues/156