### PR TITLE
Testing if increased version number in dep solves docs build.

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,4 +2,4 @@ sphinx==1.3.4
 
 ## TODO: Install unreleased develop version until htgoebel makes a release.
 # yaml2rst
-https://github.com/ypid/yaml2rst/archive/feature/yaml-fold-strip.zip
+https://github.com/ypid/yaml2rst/archive/feature/yaml-fold-strip-version-bump.zip


### PR DESCRIPTION
The build logs suggest that the library might be cached on some docs
build servers.

Ref: https://github.com/ypid/docs
Related to: https://github.com/debops/docs/issues/167