### PR TITLE
Prepare CI test for debops-keyring.

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,0 +1,4 @@
+.toggle .header {
+    display: block;
+    clear: both;
+}

--- a/docs/_templates/page.html
+++ b/docs/_templates/page.html
@@ -1,0 +1,16 @@
+{% extends "!page.html" %}
+
+{% set css_files = css_files + ["_static/custom.css"] %}
+
+{% block footer %}
+ <script type="text/javascript">
+    $(document).ready(function() {
+        $(".toggle > *").hide();
+        $(".toggle .header").show();
+        $(".toggle .header").click(function() {
+            $(this).parent().children().not(".header").toggle(400);
+            $(this).parent().children(".header").toggleClass("open");
+        })
+    });
+</script>
+{% endblock %}

--- a/docs/includes/80post.rst
+++ b/docs/includes/80post.rst
@@ -10,6 +10,7 @@
 .. _DebOps Contrib: https://github.com/debops-contrib/debops-contrib
 .. _DebOps Contrib playbooks: https://github.com/debops-contrib/debops-contrib-playbooks
 .. _DebOps Policy: http://docs.debops.org/en/latest/debops-policy/docs/index.html
+.. _Organizational structure: http://docs.debops.org/en/latest/debops-policy/docs/organizational-structure.html
 .. _debops-keyring: http://docs.debops.org/en/latest/debops-keyring/docs/index.html
 
 .. ]]]
@@ -83,5 +84,7 @@
 .. _RedRampage: https://github.com/redrampage/
 .. _Salt: http://saltstack.com/
 .. _Ubuntu 12.04 LTS (Precise Pangolin): http://releases.ubuntu.com/12.04/
+
+.. _RFC2119: https://tools.ietf.org/html/rfc2119
 
 .. ]]]

--- a/docs/includes/global.rst
+++ b/docs/includes/global.rst
@@ -792,6 +792,7 @@
 .. _DebOps Contrib: https://github.com/debops-contrib/debops-contrib
 .. _DebOps Contrib playbooks: https://github.com/debops-contrib/debops-contrib-playbooks
 .. _DebOps Policy: http://docs.debops.org/en/latest/debops-policy/docs/index.html
+.. _Organizational structure: http://docs.debops.org/en/latest/debops-policy/docs/organizational-structure.html
 .. _debops-keyring: http://docs.debops.org/en/latest/debops-keyring/docs/index.html
 
 .. ]]]
@@ -865,5 +866,7 @@
 .. _RedRampage: https://github.com/redrampage/
 .. _Salt: http://saltstack.com/
 .. _Ubuntu 12.04 LTS (Precise Pangolin): http://releases.ubuntu.com/12.04/
+
+.. _RFC2119: https://tools.ietf.org/html/rfc2119
 
 .. ]]]


### PR DESCRIPTION
The HTML, CSS and JS magic prepares the feature of hidden OpenPGP keys on the DebOps People page.
Ref: https://stackoverflow.com/questions/2454577/sphinx-restructuredtext-show-hide-code-snippets