### PR TITLE
Install Jinja2 Python3 module as user.

### DIFF
--- a/docs/bin/sphinx_conf_pre_hook
+++ b/docs/bin/sphinx_conf_pre_hook
@@ -7,3 +7,6 @@
 
 bin/linkincludes
 bin/prepare_repos_before_sphinx_runs
+
+## TODO: Move to debops-keyring.
+pip3 install --user Jinja2


### PR DESCRIPTION
Intended to fix: https://readthedocs.org/projects/debops/builds/4221617/
Docs build https://readthedocs.org currently passes. Just the DebOps
People page is missing.