### PR TITLE
Install Jinja2 Python3 module as user.

### DIFF
--- a/docs/bin/sphinx_conf_pre_hook
+++ b/docs/bin/sphinx_conf_pre_hook
@@ -5,8 +5,8 @@
 ## Run hook scripts just before Sphinx runs.
 ## Hook is installed from `conf.py` from Sphinx.
 
-bin/linkincludes
-bin/prepare_repos_before_sphinx_runs
-
 ## TODO: Move to debops-keyring.
 pip3 install --user Jinja2
+
+bin/linkincludes
+bin/prepare_repos_before_sphinx_runs


### PR DESCRIPTION
PR #183 previously did not fix the problem because Jinja2 would be installed ([successfully](https://readthedocs.org/projects/debops/builds/4221688/)) after it was already attempted to use it in `bin/prepare_repos_before_sphinx_runs`.

Fixes: #183