### PR TITLE
Add more DebOps People hyperlink definitions to allow to refer to them

### DIFF
--- a/docs/includes/80post.rst
+++ b/docs/includes/80post.rst
@@ -34,6 +34,12 @@
 .. _drybjed: https://wiki.debops.org/wiki:user:drybjed
 .. _ypid: https://wiki.debops.org/wiki:user:ypid
 .. _ypid-ansible-common: https://github.com/ypid/ypid-ansible-common/
+.. _AnBuKu: https://github.com/AnBuKu
+.. _ganto: https://github.com/ganto
+.. _htgoebel: https://github.com/htgoebel
+.. _nickjj: https://github.com/nickjj
+.. _scibi: https://github.com/scibi
+.. _do3cc: https://github.com/do3cc
 
 .. ]]]
 

--- a/docs/includes/80post.rst
+++ b/docs/includes/80post.rst
@@ -1,6 +1,7 @@
 .. DebOps project links [[[
 
 .. _DebOps: http://debops.org/
+.. _DebOps Tools: https://github.com/debops/debops-tools
 .. _DebOps Galaxy page: https://galaxy.ansible.com/debops/
 .. _DebOps API: https://github.com/debops/debops-api
 .. _DebOps mailing list: https://lists.debops.org/

--- a/docs/includes/global.rst
+++ b/docs/includes/global.rst
@@ -783,6 +783,7 @@
 .. DebOps project links [[[
 
 .. _DebOps: http://debops.org/
+.. _DebOps Tools: https://github.com/debops/debops-tools
 .. _DebOps Galaxy page: https://galaxy.ansible.com/debops/
 .. _DebOps API: https://github.com/debops/debops-api
 .. _DebOps mailing list: https://lists.debops.org/

--- a/docs/includes/global.rst
+++ b/docs/includes/global.rst
@@ -816,6 +816,12 @@
 .. _drybjed: https://wiki.debops.org/wiki:user:drybjed
 .. _ypid: https://wiki.debops.org/wiki:user:ypid
 .. _ypid-ansible-common: https://github.com/ypid/ypid-ansible-common/
+.. _AnBuKu: https://github.com/AnBuKu
+.. _ganto: https://github.com/ganto
+.. _htgoebel: https://github.com/htgoebel
+.. _nickjj: https://github.com/nickjj
+.. _scibi: https://github.com/scibi
+.. _do3cc: https://github.com/do3cc
 
 .. ]]]
 


### PR DESCRIPTION
Hyperlinks should ideally point to a location which is self hosted by
the DebOps Project (for example the wiki) but this can now be done in
one central location within the Project.