### PR TITLE
Fix regression in the "Edit on GitHub" workaround for submodules

### DIFF
--- a/docs/_lib/sphinxcontrib/debops/func.py
+++ b/docs/_lib/sphinxcontrib/debops/func.py
@@ -45,7 +45,7 @@ def get_source_file_to_url_map(start_dir='.', skip_patterns=[]):
     repo_dir_to_url_map = {}
     list_of_submod_paths = []
 
-    cur_dir = os.path.abspath(os.path.dirname(__file__))
+    cur_dir = os.path.abspath(start_dir)
 
     for submodule_path in check_output(['git', 'submodule', '--quiet', 'foreach', 'pwd']).split('\n'):
         if submodule_path.startswith(cur_dir):
@@ -103,7 +103,7 @@ def get_source_file_to_url_map(start_dir='.', skip_patterns=[]):
             relative_pagename = 'CHANGES.rst'
 
         pagename_source_file = re.sub(r'\.rst$', '', pagename_source_file)
-        print(dir_path)
+        #  print(dir_path)
         source_file_to_url_map[pagename_source_file] = {
             'url': repo_dir_to_url_map[dir_path],
             'pagename': relative_pagename,

--- a/docs/_templates/breadcrumbs.html
+++ b/docs/_templates/breadcrumbs.html
@@ -38,7 +38,7 @@
               <a href="{{ meta['github_url'] }}" class="fa fa-github"> Edit on GitHub</a>
             {% else %}
             {# Removed: github_version #}
-              <a href="{{ source_file_to_url_map[pagename]['url'] }}/blob//master/{{ source_file_to_url_map[pagename]['pagename'] }}" class="fa fa-github"> Edit on GitHub</a>
+              <a href="{{ source_file_to_url_map[pagename]['url'] }}/blob/master/{{ source_file_to_url_map[pagename]['pagename'] }}" class="fa fa-github"> Edit on GitHub</a>
             {% endif %}
           {% elif display_bitbucket %}
             {% if check_meta and 'bitbucket_url' in meta %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -152,6 +152,7 @@ html_context = {
     'last_updated': True,
     'commit': False,
     'source_file_to_url_map': debops.get_source_file_to_url_map(
+        start_dir=os.path.dirname(__file__),
         skip_patterns=[
             r'debops-keyring/docs/entities(?:\.rst)$',  # Auto generated.
             r'ansible/roles/debops[^/]+$',  # Legacy.


### PR DESCRIPTION
Problem was that after the function has been moved to a Python package
the relative paths where not as expected anymore. Pass the start dir to
the function to make the result independent of the module path where the
function is defined.