### PR TITLE
Add debops_logo to global.rst needed for debops-contrib docs

### DIFF
--- a/docs/includes/80post.rst
+++ b/docs/includes/80post.rst
@@ -2,6 +2,9 @@
 
 .. DebOps project links [[[
 
+.. |debops_logo| image:: https://debops.org/images/debops-small.png
+
+
 .. Simply "DebOps" is preferred: https://github.com/debops/docs/issues/197
 .. _DebOps project: https://debops.org/
 

--- a/docs/includes/global.rst
+++ b/docs/includes/global.rst
@@ -876,6 +876,9 @@
 
 .. DebOps project links [[[
 
+.. |debops_logo| image:: https://debops.org/images/debops-small.png
+
+
 .. Simply "DebOps" is preferred: https://github.com/debops/docs/issues/197
 .. _DebOps project: https://debops.org/
 


### PR DESCRIPTION
Cherry picks one change from: https://github.com/debops/docs/pull/236