### PR TITLE
Fix global.rst/all.rst symlink issue

### DIFF
--- a/docs/_bin/linkincludes
+++ b/docs/_bin/linkincludes
@@ -22,7 +22,7 @@ do
 
     ## Should not be needed but for some reason when setting up DebOps Contrib,
     ## it was needed for CHANGES.rst.
-    ln -sf "$DOCS_DIR/includes" ../../
+    ln -sf "./docs/includes" ../../
 
     popd 1>/dev/null
     ## Print for debugging for now.


### PR DESCRIPTION
Problem was that when you used a `role.rst` which as included via the
`all.rst` file, the `linkincludes` script did link to the generic
include dir without your custom `role.rst` and `all.rst` causing
undefined warnings.

The problem did not yet occur in DebOps but in my personal docs repo: https://travis-ci.org/ypid/ypid-ansible-role-docs/builds/195994381
But as I avoided redundancy, this repo here is the only place where the file exists :wink: